### PR TITLE
Update CT-WeierstrassSineProduct.js

### DIFF
--- a/nonofficial/CT-WeierstrassSineProduct.js
+++ b/nonofficial/CT-WeierstrassSineProduct.js
@@ -145,6 +145,7 @@ var setInternalState = (state) => {
 
 var postPublish = () => {
     q = BigNumber.ONE;
+    updateSineRatio();
 }
 
 var getPrimaryEquation = () => {


### PR DESCRIPTION
fixed: chi wasn't reset after publish